### PR TITLE
feat: Add dashboard view with card layout

### DIFF
--- a/frontend/src/lib/components/app/AppSidebar.svelte
+++ b/frontend/src/lib/components/app/AppSidebar.svelte
@@ -5,6 +5,7 @@
 	import Envios from 'lucide-svelte/icons/truck';
 	import Tractor from 'lucide-svelte/icons/tractor';
 	import Sparkles from 'lucide-svelte/icons/sparkles';
+	import HomeIcon from 'lucide-svelte/icons/home';
 	import CreditCard from 'lucide-svelte/icons/credit-card';
 	import LogOut from 'lucide-svelte/icons/log-out';
 	import BadgeCheck from 'lucide-svelte/icons/badge-check';
@@ -26,6 +27,12 @@
 
 	// Menu items.
 	const items: Item[] = $state([
+		{
+			title: 'Dashboard',
+			url: '/dashboard',
+			icon: HomeIcon,
+			active: false
+		},
 		{
 			title: 'Documentos',
 			url: '/documento',

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import {
+    Card,
+    CardContent,
+    CardFooter,
+    CardHeader,
+    CardTitle
+  } from "$lib/components/ui/card/index.ts";
+</script>
+
+<h1 class="text-2xl font-bold mb-4">Dashboard</h1>
+
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4">
+  <Card>
+    <CardHeader>
+      <CardTitle>Clients</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <p>Manage client information</p>
+    </CardContent>
+    <CardFooter>
+      <p>View Clients</p>
+    </CardFooter>
+  </Card>
+
+  <Card>
+    <CardHeader>
+      <CardTitle>Products</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <p>Manage product information</p>
+    </CardContent>
+    <CardFooter>
+      <p>View Products</p>
+    </CardFooter>
+  </Card>
+
+  <Card>
+    <CardHeader>
+      <CardTitle>Documents</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <p>Manage documents</p>
+    </CardContent>
+    <CardFooter>
+      <p>View Documents</p>
+    </CardFooter>
+  </Card>
+</div>

--- a/frontend/src/routes/dashboard/+page.ts
+++ b/frontend/src/routes/dashboard/+page.ts
@@ -1,0 +1,1 @@
+// This file can be used for loading data or defining actions for the dashboard page.


### PR DESCRIPTION
This commit introduces a new dashboard view to the frontend application.

The dashboard is accessible via the `/dashboard` route and features a card-based layout to display different sections or modules of the application.

Key changes:
- Created a new Svelte component `frontend/src/routes/dashboard/+page.svelte` for the dashboard.
- Utilized the existing `Card` component from `frontend/src/lib/components/ui/card` to display placeholder cards for Clients, Products, and Documents.
- Added a route configuration file `frontend/src/routes/dashboard/+page.ts`.
- Updated `frontend/src/lib/components/app/AppSidebar.svelte` to include a navigation link to the new dashboard page, using the `HomeIcon`.
- Applied basic Tailwind CSS styling to the dashboard for a responsive grid layout and appropriate spacing.