### PR TITLE
Fix: Implement password hashing and user management endpoints

### DIFF
--- a/backend/db/dbFinal.sql
+++ b/backend/db/dbFinal.sql
@@ -79,7 +79,7 @@ DROP TABLE IF EXISTS `usuario`;
 CREATE TABLE `usuario` (
   `id` int NOT NULL AUTO_INCREMENT,
   `user` varchar(45) NOT NULL,
-  `password` varchar(45) NOT NULL,
+  `password` varchar(255) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `user_UNIQUE` (`user`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
@@ -91,7 +91,7 @@ CREATE TABLE `usuario` (
 
 LOCK TABLES `usuario` WRITE;
 /*!40000 ALTER TABLE `usuario` DISABLE KEYS */;
-INSERT INTO `usuario` VALUES (1,'admin','admin');
+INSERT INTO `usuario` VALUES (1,'admin','$2y$10$FJWajhAP2ydJs5YNxxdu8eaaNP4yGDLnZdUSKmxovbr2NE9JcixJG');
 /*!40000 ALTER TABLE `usuario` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;

--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -1,6 +1,7 @@
 <?php
 include "cliente.php";
 include "producto.php";
+include "usuario.php";
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -316,6 +317,131 @@ $app->post('/api/productos', function (Request $request, Response $response) {
     }
 });
 
+// Endpoint para login de usuario
+$app->post('/api/login', function (Request $request, Response $response) {
+    $repo = new UsuarioRepo();
+    try {
+        $data = json_decode($request->getBody(), true);
 
+        if (!isset($data['user']) || !isset($data['password'])) {
+            throw new Exception('Faltan campos requeridos: user y password');
+        }
+
+        $usuario = $repo->login($data['user'], $data['password']);
+
+        if ($usuario) {
+            $response->getBody()->write(json_encode([
+                "mensaje" => "Login successful"
+            ]));
+            return $response
+                ->withHeader('Content-Type', 'application/json')
+                ->withStatus(200);
+        } else {
+            $response->getBody()->write(json_encode([
+                "mensaje" => "Invalid credentials"
+            ]));
+            return $response
+                ->withHeader('Content-Type', 'application/json')
+                ->withStatus(401);
+        }
+    } catch (Exception $err) {
+        error_log($err->getMessage());
+        $response->getBody()->write(json_encode([
+            "mensaje" => $err->getMessage()
+        ]));
+        return $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus(400);
+    }
+});
+
+// Endpoint para crear un nuevo usuario
+$app->post('/api/usuarios/create', function (Request $request, Response $response) {
+    $repo = new UsuarioRepo();
+    try {
+        $data = json_decode($request->getBody(), true);
+
+        if (!isset($data['user']) || !isset($data['password'])) {
+            throw new Exception('Faltan campos requeridos: user y password');
+        }
+
+        $repo->create($data['user'], $data['password']);
+
+        $response->getBody()->write(json_encode([
+            "mensaje" => "User created successfully"
+        ]));
+        return $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus(201);
+    } catch (PDOException $e) {
+        error_log($e->getMessage());
+        // Check if the error is due to a duplicate entry (error code 23000)
+        if ($e->getCode() == '23000') {
+            $response->getBody()->write(json_encode([
+                "mensaje" => "User already exists"
+            ]));
+            return $response
+                ->withHeader('Content-Type', 'application/json')
+                ->withStatus(409); // Conflict
+        } else {
+            $response->getBody()->write(json_encode([
+                "mensaje" => "Error creating user: " . $e->getMessage()
+            ]));
+            return $response
+                ->withHeader('Content-Type', 'application/json')
+                ->withStatus(400);
+        }
+    } catch (Exception $err) {
+        error_log($err->getMessage());
+        $response->getBody()->write(json_encode([
+            "mensaje" => $err->getMessage()
+        ]));
+        return $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus(400);
+    }
+});
+
+// Endpoint para actualizar la contraseña de un usuario
+$app->patch('/api/usuarios/update-password', function (Request $request, Response $response) {
+    $repo = new UsuarioRepo();
+    try {
+        $data = json_decode($request->getBody(), true);
+
+        if (!isset($data['id']) || !isset($data['newPassword'])) {
+            throw new Exception('Faltan campos requeridos: id y newPassword');
+        }
+
+        $success = $repo->updatePassword($data['id'], $data['newPassword']);
+
+        if ($success) {
+            $response->getBody()->write(json_encode([
+                "mensaje" => "Password updated successfully"
+            ]));
+            return $response
+                ->withHeader('Content-Type', 'application/json')
+                ->withStatus(200);
+        } else {
+            // This part might be tricky as execute() returns true on success, false on error.
+            // It doesn't directly tell us if the user was not found or if another error occurred.
+            // A more robust way would be to check if the user exists before attempting an update,
+            // or check the number of affected rows. For now, a generic error for failure.
+            $response->getBody()->write(json_encode([
+                "mensaje" => "Failed to update password. User not found or other error."
+            ]));
+            return $response
+                ->withHeader('Content-Type', 'application/json')
+                ->withStatus(400); // Or 404 if we could confirm user not found
+        }
+    } catch (Exception $err) {
+        error_log($err->getMessage());
+        $response->getBody()->write(json_encode([
+            "mensaje" => $err->getMessage()
+        ]));
+        return $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus(400);
+    }
+});
 
 $app->run();

--- a/backend/public/usuario.php
+++ b/backend/public/usuario.php
@@ -35,4 +35,18 @@ class UsuarioRepo
         }
         return null;
     }
+
+    public function create(string $user, string $password): void
+    {
+        $hashedPassword = password_hash($password, PASSWORD_DEFAULT);
+        $stmt = $this->db->prepare("INSERT INTO usuario (user, password) VALUES (?, ?)");
+        $stmt->execute([$user, $hashedPassword]);
+    }
+
+    public function updatePassword(int $id, string $newPassword): bool
+    {
+        $hashedPassword = password_hash($newPassword, PASSWORD_DEFAULT);
+        $stmt = $this->db->prepare("UPDATE usuario SET password = ? WHERE id = ?");
+        return $stmt->execute([$hashedPassword, $id]);
+    }
 }


### PR DESCRIPTION
This commit addresses password security vulnerabilities and adds basic user management functionality.

Changes include:
- Modified `UsuarioRepo` in `backend/public/usuario.php`:
    - Added `create()` method with password hashing (using `password_hash()`).
    - Added `updatePassword()` method with password hashing.
    - Verified `login()` method uses `password_verify()`.
- Updated `backend/db/dbFinal.sql`:
    - Changed `usuario.password` column to `VARCHAR(255)`.
    - Set a hashed default password for the 'admin' user.
- Added API endpoints to `backend/public/index.php`:
    - `POST /api/login` for user login.
    - `POST /api/usuarios/create` for user creation.
    - `PATCH /api/usuarios/update-password` for password updates.
    - Included `usuario.php`.

Testing Limitations:
I was unable to complete manual testing of the new API endpoints and user management logic due to persistent database connectivity issues in the testing environment. The `db.php` file contains hardcoded credentials ("root", "wltr6969") which may not be valid for the environment, causing timeouts when PHP scripts attempt to connect to the database.

The implemented code provides the necessary security improvements for password storage, but runtime verification of the full user management flow is pending a resolution of the database connectivity problem.